### PR TITLE
[bug] Fix NotificationService by adding parameter `payload`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Based on clean architecture
 ### Features
 
 - [x] 캘린더 위젯 넘길 때(월 바꿀 때) Frame drop 발생
-- [ ] Notification Payload 제대로 설정 안돼있어서 클릭 후 제대로 동작하지 않음
+- [x] Notification Payload 제대로 설정 안돼있어서 클릭 후 제대로 동작하지 않음
 - [ ] 백엔드 요청 안정화
   - [ ] 백엔드에서 요청 오래 걸릴 때(에러, cold state이거나) 빠르게 끊고 새로 요청 보내는 로직
 - [ ] 테스트 코드 재작성

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -165,7 +165,7 @@ class NotificationServiceImpl implements NotificationService {
 
     await _localNotifyPlugin.zonedSchedule(
       id,
-      "청모",
+      appName,
       title,
       scheduleDate,
       details,

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -21,11 +21,13 @@ abstract class NotificationService {
   Future<void> init();
   Future<void> onDidReceiveNotificationResponse({required String link});
   Future<void> checkPreviousDayForNotify({required Schedule schedule});
-  Future<void> addNotifySchedule(
-      {required int id,
-      required String appName,
-      required String title,
-      required tz.TZDateTime scheduleDate});
+  Future<void> addNotifySchedule({
+    required int id,
+    required String appName,
+    required String title,
+    required tz.TZDateTime scheduleDate,
+    required String payload,
+  });
   Future<void> cancelNotifySchedule({required String link});
   Future<void> checkScheduledNotifications();
   Future<void> addTestNotifySchedule({required int id});
@@ -128,18 +130,25 @@ class NotificationServiceImpl implements NotificationService {
     }
 
     await addNotifySchedule(
-        id: id, appName: '청모', title: title, scheduleDate: scheduleDate);
+      id: id,
+      appName: '청모',
+      title: title,
+      scheduleDate: scheduleDate,
+      payload: schedule.link,
+    );
   }
 
   /// Add notification schedule.
   ///
   /// Called by notifyScheduleAtPreviousDay()
   @override
-  Future<void> addNotifySchedule(
-      {required int id,
-      required String appName,
-      required String title,
-      required tz.TZDateTime scheduleDate}) async {
+  Future<void> addNotifySchedule({
+    required int id,
+    required String appName,
+    required String title,
+    required tz.TZDateTime scheduleDate,
+    required String payload,
+  }) async {
     NotificationDetails details = const NotificationDetails(
       iOS: DarwinNotificationDetails(
         presentAlert: true,
@@ -163,7 +172,7 @@ class NotificationServiceImpl implements NotificationService {
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
       androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-      payload: scheduleDate.toIso8601String(),
+      payload: payload,
     );
   }
 


### PR DESCRIPTION
## Problem

- When user clicks push notification, opening detail schedule was intended.
- But there was missed parameter, so opening detail page didn't work.

## Changes

- Add parameter `payload` at `addNotifySchedule` in `notification_service.dart`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced notification scheduling to include customizable payloads, improving notification handling after clicking.

- **Documentation**
  - Updated the project’s feature list to reflect the completion of the notification payload functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->