### PR TITLE
[refact] 01 - Remove getx dependencies

### DIFF
--- a/lib/core/navigation/app_navigation.dart
+++ b/lib/core/navigation/app_navigation.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/widgets.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:get/get.dart';
 import 'package:injectable/injectable.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 
+import '../navigation/app_navigation.dart';
 import '../../domain/usecases/usecases.dart';
 import '../../domain/entities/schedule.dart';
 import '../di/di.dart';
@@ -92,10 +92,11 @@ class NotificationServiceImpl implements NotificationService {
     final Schedule? targetSchedule =
         await getScheduleByLinkUsecase.execute(link);
     if (targetSchedule != null) {
-      Get.toNamed('/');
-      Get.toNamed('/detail', arguments: targetSchedule);
+      navigatorKey.currentState?.pushNamed('/');
+      navigatorKey.currentState
+          ?.pushNamed('/detail', arguments: targetSchedule);
     } else {
-      Get.toNamed('/');
+      navigatorKey.currentState?.pushNamed('/');
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,14 +2,15 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
-import 'package:get/get.dart';
 
 import 'core/di/di.dart';
 import 'core/env.dart';
+import 'core/navigation/app_navigation.dart';
 import 'core/services/notification_service.dart';
 import 'presentation/pages/pages.dart';
 import 'presentation/theme/dark_theme.dart';
 import 'presentation/theme/light_theme.dart';
+import 'domain/entities/schedule.dart';
 
 @pragma('vm:entry-point')
 void main() async {
@@ -36,8 +37,9 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GetMaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
+      navigatorKey: navigatorKey,
       theme: LightTheme.theme,
       darkTheme: DarkTheme.theme,
       themeMode: ThemeMode.system,
@@ -55,7 +57,11 @@ class MainApp extends StatelessWidget {
         '/': (context) => const CreatePage(),
         // ignore: prefer_const_constructors
         '/calendar': (context) => CalendarPage(),
-        '/detail': (context) => DetailPage(),
+        '/detail': (context) {
+          final schedule =
+              ModalRoute.of(context)!.settings.arguments as Schedule;
+          return DetailPage(schedule: schedule);
+        },
         '/about': (context) => const AboutPage(),
         '/about/developer_info': (context) => const DeveloperInfoPage(),
       },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  bloc:
+    dependency: transitive
+    description:
+      name: bloc
+      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -257,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.4"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:
@@ -294,6 +310,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_bloc:
+    dependency: "direct main"
+    description:
+      name: flutter_bloc
+      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.1"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -381,14 +405,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  get:
-    dependency: "direct main"
-    description:
-      name: get
-      sha256: c79eeb4339f1f3deffd9ec912f8a923834bec55f7b49c9e882b8fef2c139d425
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.7.2"
   get_it:
     dependency: "direct main"
     description:
@@ -605,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   octo_image:
     dependency: transitive
     description:
@@ -773,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,14 +10,15 @@ dependencies:
   cached_network_image: ^3.4.1
   dio: ^5.8.0+1
   dotlottie_loader: ^0.0.4
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
+  flutter_bloc: ^9.1.1
   flutter_local_notifications: ^18.0.1
   flutter_localizations:
     sdk: flutter
   flutter_native_splash: ^2.4.4
   freezed_annotation: ^2.4.4
-  get: ^4.7.2
   get_it: ^8.0.3
   injectable: ^2.5.0
   injectable_generator: ^2.7.0


### PR DESCRIPTION
## Related Issue

- #9 

## Changes

- remove getx, pub add bloc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved navigation handling across the app by introducing a global navigation key.
- **Refactor**
  - Switched from using the GetX navigation package to Flutter’s built-in navigation system.
  - Updated route handling to pass data more explicitly between pages.
- **Chores**
  - Updated dependencies: added `equatable` and `flutter_bloc`, and removed the `get` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->