### PR TITLE
feat: apply BlocBuilder, BlocProvider instead of Obx

### DIFF
--- a/lib/presentation/pages/calendar_page.dart
+++ b/lib/presentation/pages/calendar_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-import '../controllers/calendar_viewmodel.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/calendar/calendar_bloc.dart';
+import '../bloc/calendar/calendar_event.dart';
+import '../bloc/calendar/calendar_state.dart';
 import '../theme/palette.dart';
 import '../widgets/calendar_list_view.dart';
 import '../widgets/calendar_view.dart';
@@ -14,47 +17,54 @@ class CalendarPage extends StatefulWidget {
 }
 
 class _CalendarPageState extends State<CalendarPage> {
-  final CalendarController _controller = Get.put(CalendarController());
+  late final CalendarBloc bloc;
   bool _isCalendarView = true;
 
   @override
   void initState() {
     super.initState();
+    bloc = CalendarBloc()..add(CalendarStarted());
   }
 
   @override
   void dispose() {
-    Get.delete<CalendarController>();
+    bloc.close();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          '일정',
-          style: TextStyle(
-              fontSize: 18, fontWeight: FontWeight.bold, color: Palette.black),
-        ),
-        actions: [
-          IconButton(
-            icon: Icon(_isCalendarView ? Icons.list : Icons.calendar_month),
-            onPressed: () {
-              setState(() {
-                _isCalendarView = !_isCalendarView;
-              });
-            },
+    return BlocProvider<CalendarBloc>.value(
+      value: bloc,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            '일정',
+            style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: Palette.black),
           ),
-        ],
+          actions: [
+            IconButton(
+              icon: Icon(_isCalendarView ? Icons.list : Icons.calendar_month),
+              onPressed: () {
+                setState(() {
+                  _isCalendarView = !_isCalendarView;
+                });
+              },
+            ),
+          ],
+        ),
+        body:
+            BlocBuilder<CalendarBloc, CalendarState>(builder: (context, state) {
+          return state.isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : _isCalendarView
+                  ? const CalendarView()
+                  : const CalendarListView();
+        }),
       ),
-      body: Obx(() {
-        return _controller.isLoading.value
-            ? const Center(child: CircularProgressIndicator())
-            : _isCalendarView
-                ? CalendarView()
-                : CalendarListView();
-      }),
     );
   }
 }

--- a/lib/presentation/pages/create_page.dart
+++ b/lib/presentation/pages/create_page.dart
@@ -5,15 +5,16 @@
 import 'package:dotlottie_loader/dotlottie_loader.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:lottie/lottie.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/di/di.dart';
+import '../../core/navigation/app_navigation.dart';
 import '../../core/services/preferences_checker.dart';
 import '../../core/services/tutorial_manager.dart';
 import '../../core/utils/constants.dart';
-import '../controllers/create_viewmodel.dart';
+import '../bloc/create/create_cubit.dart';
 import '../theme/palette.dart';
 import '../widgets/schedule_detail_column.dart';
 
@@ -25,7 +26,7 @@ class CreatePage extends StatefulWidget {
 }
 
 class _CreatePageState extends State<CreatePage> {
-  final CreateController controller = Get.put(CreateController());
+  late final CreateCubit cubit;
   final PreferencesChecker preferencesChecker = getIt<PreferencesChecker>();
   final TextEditingController _textEditingController = TextEditingController();
 
@@ -37,6 +38,8 @@ class _CreatePageState extends State<CreatePage> {
   @override
   void initState() {
     super.initState();
+    cubit = CreateCubit();
+    cubit.checkIfNotification();
     _initTutorial();
   }
 
@@ -58,230 +61,247 @@ class _CreatePageState extends State<CreatePage> {
   void _onSubmit() {
     String userInput = _textEditingController.text.trim();
     if (userInput.isNotEmpty) {
-      controller.analyzeLink(userInput);
+      cubit.analyzeLink(userInput);
       _textEditingController.clear();
     }
   }
 
   @override
+  void dispose() {
+    cubit.close();
+    _textEditingController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    controller.checkIfNotification();
-    return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          key: calendarPageKey,
-          icon: const Icon(Icons.calendar_today),
-          onPressed: () {
-            Get.toNamed('/calendar');
-          },
-        ),
-        actions: [
-          /// Only shows notification button in `kDebugMode`.
-          kDebugMode
-              ? IconButton(
-                  icon: const Icon(Icons.notifications),
-                  onPressed: () {
-                    controller.notificationService.addTestNotifySchedule(id: 1);
-                    controller.notificationService
-                        .checkScheduledNotifications();
-                    Get.defaultDialog(
-                      title: "알림",
-                      middleText: "스케쥴이 등록되었습니다.",
-                      textConfirm: "확인",
-                      textCancel: "취소",
-                      onConfirm: () {
-                        Get.back();
-                      },
-                      onCancel: () {},
-                    );
-                  },
-                )
-              : Container(),
-          PopupMenuButton<String>(
-            icon: const Icon(Icons.more_vert),
-            onSelected: (value) async {
-              switch (value) {
-                case 'terms':
-                  final Uri url = Uri.parse(Constants.termsUrl);
-                  if (await canLaunchUrl(url)) {
-                    await launchUrl(url, mode: LaunchMode.externalApplication);
-                  }
-                  break;
-                case 'privacy':
-                  final Uri url = Uri.parse(Constants.privacyUrl);
-                  if (await canLaunchUrl(url)) {
-                    await launchUrl(url, mode: LaunchMode.externalApplication);
-                  }
-                  break;
-                case 'about':
-                  Get.toNamed('/about');
-                  break;
-              }
+    return BlocProvider<CreateCubit>.value(
+      value: cubit,
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            key: calendarPageKey,
+            icon: const Icon(Icons.calendar_today),
+            onPressed: () {
+              navigatorKey.currentState?.pushNamed('/calendar');
             },
-            itemBuilder: (context) => [
-              const PopupMenuItem(
-                value: 'terms',
-                child: Text('이용 약관'),
-              ),
-              const PopupMenuItem(
-                value: 'privacy',
-                child: Text('개인정보 처리방침'),
-              ),
-              const PopupMenuItem(
-                value: 'about',
-                child: Text('앱 정보'),
-              ),
-            ],
           ),
-        ],
-      ),
-      body: Stack(
-        children: [
-          const Positioned(
-            top: 10,
-            left: 30,
-            child: Text('홈',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-          ),
-          Center(
-            child: Obx(() {
-              if (controller.isLoading.value) {
-                return Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(
-                      width: 250,
-                      height: 250,
-                      child: DotLottieLoader.fromAsset(
-                          'assets/images/analyze.lottie', frameBuilder:
-                              (BuildContext ctx, DotLottie? dotlottie) {
-                        if (dotlottie != null) {
-                          return Lottie.memory(
-                              dotlottie.animations.values.single);
-                        } else {
-                          return const CircularProgressIndicator();
-                        }
-                      }),
-                    ),
-                    const SizedBox(height: 16),
-                    const Text('링크 분석 중...', style: TextStyle(fontSize: 16)),
-                  ],
-                );
-              }
-              return controller.isError.value
-                  ? const Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '다시 시도해주세요.',
-                          style: TextStyle(
-                              fontSize: 18, fontWeight: FontWeight.bold),
-                        ),
-                        Text(
-                          '잠시 서버에 문제가 생겼어요.',
-                          style: TextStyle(fontSize: 14),
-                        )
-                      ],
-                    )
-                  : controller.schedule.value?.link != null
-                      ? ScheduleDetailColumn(
-                          schedule: controller.schedule.value!,
-                          extraChildren: [
-                            const SizedBox(height: 12),
-                            Text(
-                              '분석 결과를 일정에 추가할게요.',
-                              style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w500,
-                                  color: Palette.burgundy),
-                            ),
-                          ],
-                        )
-                      : Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Text(
-                              key: resultBodyKey,
-                              '모바일 청첩장을 첨부해주세요.',
-                              style: const TextStyle(
-                                  fontSize: 18, fontWeight: FontWeight.bold),
-                            ),
-                            const Text(
-                              'AI가 자동으로 일정을 분석해드릴게요.',
-                              style: TextStyle(fontSize: 14),
-                            )
-                          ],
-                        );
-            }),
-          ),
-        ],
-      ),
-      bottomSheet: Obx(() {
-        return controller.schedule.value?.link != null
-            ? Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
+          actions: [
+            /// Only shows notification button in `kDebugMode`.
+            kDebugMode
+                ? IconButton(
+                    icon: const Icon(Icons.notifications),
                     onPressed: () {
-                      controller.resetState();
-                      Get.snackbar('성공', '일정을 캘린더에 저장했습니다.');
+                      cubit.notificationService.addTestNotifySchedule(id: 1);
+                      cubit.notificationService.checkScheduledNotifications();
+                      showDialog(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          title: const Text('알림'),
+                          content: const Text('스케쥴이 등록되었습니다.'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.of(context).pop(),
+                              child: const Text('확인'),
+                            ),
+                          ],
+                        ),
+                      );
                     },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Palette.burgundy,
-                      foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
-                    child: const Text(
-                      "확인",
-                      style:
-                          TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                    ),
-                  ),
+                  )
+                : Container(),
+            PopupMenuButton<String>(
+              icon: const Icon(Icons.more_vert),
+              onSelected: (value) async {
+                switch (value) {
+                  case 'terms':
+                    final Uri url = Uri.parse(Constants.termsUrl);
+                    if (await canLaunchUrl(url)) {
+                      await launchUrl(url,
+                          mode: LaunchMode.externalApplication);
+                    }
+                    break;
+                  case 'privacy':
+                    final Uri url = Uri.parse(Constants.privacyUrl);
+                    if (await canLaunchUrl(url)) {
+                      await launchUrl(url,
+                          mode: LaunchMode.externalApplication);
+                    }
+                    break;
+                  case 'about':
+                    navigatorKey.currentState?.pushNamed('/about');
+                    break;
+                }
+              },
+              itemBuilder: (context) => [
+                const PopupMenuItem(
+                  value: 'terms',
+                  child: Text('이용 약관'),
                 ),
-              )
-            : Padding(
-                key: linkInputKey,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(12),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black
-                            .withValues(red: 0, blue: 0, green: 0, alpha: 0.1),
-                        blurRadius: 10,
-                        spreadRadius: 1,
+                const PopupMenuItem(
+                  value: 'privacy',
+                  child: Text('개인정보 처리방침'),
+                ),
+                const PopupMenuItem(
+                  value: 'about',
+                  child: Text('앱 정보'),
+                ),
+              ],
+            ),
+          ],
+        ),
+        body: Stack(
+          children: [
+            const Positioned(
+              top: 10,
+              left: 30,
+              child: Text('홈',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ),
+            Center(
+              child: BlocBuilder<CreateCubit, CreateState>(
+                  builder: (context, state) {
+                if (state.isLoading) {
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 250,
+                        height: 250,
+                        child: DotLottieLoader.fromAsset(
+                            'assets/images/analyze.lottie', frameBuilder:
+                                (BuildContext ctx, DotLottie? dotlottie) {
+                          if (dotlottie != null) {
+                            return Lottie.memory(
+                                dotlottie.animations.values.single);
+                          } else {
+                            return const CircularProgressIndicator();
+                          }
+                        }),
                       ),
+                      const SizedBox(height: 16),
+                      const Text('링크 분석 중...', style: TextStyle(fontSize: 16)),
                     ],
-                  ),
-                  child: TextField(
-                    controller: _textEditingController,
-                    onSubmitted: (value) => _onSubmit(),
-                    style: const TextStyle(fontSize: 14),
-                    decoration: InputDecoration(
-                      hintText: '링크 입력...',
-                      hintStyle:
-                          TextStyle(fontSize: 14, color: Palette.grey500),
-                      contentPadding: const EdgeInsets.symmetric(
-                          vertical: 12, horizontal: 16),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(8),
-                        borderSide: BorderSide.none,
+                  );
+                }
+                return state.isError
+                    ? const Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            '다시 시도해주세요.',
+                            style: TextStyle(
+                                fontSize: 18, fontWeight: FontWeight.bold),
+                          ),
+                          Text(
+                            '잠시 서버에 문제가 생겼어요.',
+                            style: TextStyle(fontSize: 14),
+                          )
+                        ],
+                      )
+                    : state.schedule != null
+                        ? ScheduleDetailColumn(
+                            schedule: state.schedule!,
+                            extraChildren: [
+                              const SizedBox(height: 12),
+                              Text(
+                                '분석 결과를 일정에 추가할게요.',
+                                style: TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w500,
+                                    color: Palette.burgundy),
+                              ),
+                            ],
+                          )
+                        : Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                key: resultBodyKey,
+                                '모바일 청첩장을 첨부해주세요.',
+                                style: const TextStyle(
+                                    fontSize: 18, fontWeight: FontWeight.bold),
+                              ),
+                              const Text(
+                                'AI가 자동으로 일정을 분석해드릴게요.',
+                                style: TextStyle(fontSize: 14),
+                              )
+                            ],
+                          );
+              }),
+            ),
+          ],
+        ),
+        bottomSheet:
+            BlocBuilder<CreateCubit, CreateState>(builder: (context, state) {
+          return state.schedule != null
+              ? Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        cubit.resetState();
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('일정을 캘린더에 저장했습니다.')),
+                        );
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Palette.burgundy,
+                        foregroundColor: Colors.white,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
                       ),
-                      suffixIcon: IconButton(
-                        icon: const Icon(Icons.send, size: 20),
-                        onPressed: _onSubmit,
+                      child: const Text(
+                        "확인",
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold),
                       ),
                     ),
                   ),
-                ),
-              );
-      }),
+                )
+              : Padding(
+                  key: linkInputKey,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(
+                              red: 0, blue: 0, green: 0, alpha: 0.1),
+                          blurRadius: 10,
+                          spreadRadius: 1,
+                        ),
+                      ],
+                    ),
+                    child: TextField(
+                      controller: _textEditingController,
+                      onSubmitted: (value) => _onSubmit(),
+                      style: const TextStyle(fontSize: 14),
+                      decoration: InputDecoration(
+                        hintText: '링크 입력...',
+                        hintStyle:
+                            TextStyle(fontSize: 14, color: Palette.grey500),
+                        contentPadding: const EdgeInsets.symmetric(
+                            vertical: 12, horizontal: 16),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide.none,
+                        ),
+                        suffixIcon: IconButton(
+                          icon: const Icon(Icons.send, size: 20),
+                          onPressed: _onSubmit,
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+        }),
+      ),
     );
   }
 }

--- a/lib/presentation/pages/detail_page.dart
+++ b/lib/presentation/pages/detail_page.dart
@@ -1,14 +1,15 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../domain/entities/schedule.dart';
 import '../../core/utils/date_extension.dart';
-import '../controllers/detail_viewmodel.dart';
+import '../bloc/detail/detail_cubit.dart';
+import '../../core/navigation/app_navigation.dart';
 
 class DetailPage extends StatefulWidget {
-  DetailPage({super.key});
-  final Schedule schedule = Get.arguments as Schedule;
+  final Schedule schedule;
+  const DetailPage({super.key, required this.schedule});
 
   @override
   // ignore: library_private_types_in_public_api
@@ -18,7 +19,7 @@ class DetailPage extends StatefulWidget {
 class _DetailPageState extends State<DetailPage> {
   bool editMode = false;
 
-  final DetailController controller = Get.put(DetailController());
+  late final DetailCubit cubit;
   final TextEditingController groomController = TextEditingController();
   final TextEditingController brideController = TextEditingController();
   final TextEditingController locationController = TextEditingController();
@@ -29,7 +30,8 @@ class _DetailPageState extends State<DetailPage> {
   @override
   void initState() {
     super.initState();
-    controller.schedule.value = widget.schedule;
+    cubit = DetailCubit();
+    cubit.setSchedule(widget.schedule);
     groomController.text = widget.schedule.groom;
     brideController.text = widget.schedule.bride;
     locationController.text = widget.schedule.location;
@@ -45,6 +47,7 @@ class _DetailPageState extends State<DetailPage> {
     locationController.dispose();
     linkController.dispose();
     // payController.dispose();
+    cubit.close();
     super.dispose();
   }
 
@@ -57,15 +60,17 @@ class _DetailPageState extends State<DetailPage> {
   void saveChanges() {
     setState(() {
       final Schedule editedSchedule = Schedule(
-          link: controller.schedule.value!.link,
-          thumbnail: controller.schedule.value!.thumbnail,
+          link: cubit.state.schedule!.link,
+          thumbnail: cubit.state.schedule!.thumbnail,
           groom: groomController.text,
           bride: brideController.text,
           date: selectedDate!,
           location: locationController.text);
-      controller.editSchedule(editedSchedule);
+      cubit.editSchedule(editedSchedule);
       editMode = false;
-      Get.snackbar('성공', '일정이 변경되었습니다.');
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('일정이 변경되었습니다.')),
+      );
     });
   }
 
@@ -111,8 +116,9 @@ class _DetailPageState extends State<DetailPage> {
   }
 
   void _showDeleteDialog() {
-    Get.dialog(
-      AlertDialog(
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
         ),
@@ -129,7 +135,7 @@ class _DetailPageState extends State<DetailPage> {
         ),
         actions: [
           TextButton(
-            onPressed: () => Get.back(),
+            onPressed: () => Navigator.of(context).pop(),
             child: const Text("취소", style: TextStyle(color: Colors.grey)),
           ),
           ElevatedButton(
@@ -140,9 +146,12 @@ class _DetailPageState extends State<DetailPage> {
               ),
             ),
             onPressed: () {
-              controller.deleteSchedule(controller.schedule.value!.link);
-              Get.snackbar('성공', '일정이 삭제되었습니다.');
-              Get.until((route) => route.settings.name == '/calendar');
+              cubit.deleteSchedule(cubit.state.schedule!.link);
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('일정이 삭제되었습니다.')),
+              );
+              navigatorKey.currentState
+                  ?.popUntil((route) => route.settings.name == '/calendar');
             },
             child: const Text("삭제", style: TextStyle(color: Colors.white)),
           ),
@@ -153,185 +162,189 @@ class _DetailPageState extends State<DetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) return;
-        Get.until((route) => route.settings.name == '/calendar');
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          actions: [
-            IconButton(
-              icon: Icon(editMode ? Icons.save : Icons.edit),
-              onPressed: editMode ? saveChanges : toggleEditMode,
-            ),
-            editMode
-                ? Container()
-                : IconButton(
-                    icon: const Icon(Icons.delete),
-                    onPressed: () {
-                      _showDeleteDialog();
-                    },
-                  ),
-          ],
-        ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              // 📸 사진 (수정 불가능)
-              Container(
-                width: 200,
-                height: 200,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  image: DecorationImage(
-                    image: CachedNetworkImageProvider(
-                        controller.schedule.value!.thumbnail),
-                    fit: BoxFit.cover,
-                  ),
-                ),
+    return BlocProvider<DetailCubit>.value(
+      value: cubit,
+      child: PopScope(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, result) {
+          if (didPop) return;
+          navigatorKey.currentState
+              ?.popUntil((route) => route.settings.name == '/calendar');
+        },
+        child: Scaffold(
+          appBar: AppBar(
+            actions: [
+              IconButton(
+                icon: Icon(editMode ? Icons.save : Icons.edit),
+                onPressed: editMode ? saveChanges : toggleEditMode,
               ),
-              const SizedBox(height: 12),
-
-              // 👰‍♀️ & 🤵‍♂️ 신랑 & 신부 (수정 가능)
-              editMode
-                  ? Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Expanded(
-                          child: Padding(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 16.0),
-                            child: TextField(
-                              controller: groomController,
-                              decoration:
-                                  customInputDecoration(labelText: '신랑'),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Padding(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 16.0),
-                            child: TextField(
-                              controller: brideController,
-                              decoration:
-                                  customInputDecoration(labelText: '신부'),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                          ),
-                        ),
-                      ],
-                    )
-                  : Text(
-                      '🤵‍♂️ ${controller.schedule.value!.groom} & 👰‍♀️ ${controller.schedule.value!.bride}',
-                      style: const TextStyle(
-                          fontSize: 18, fontWeight: FontWeight.bold),
-                    ),
-
-              const SizedBox(height: 16),
-
-              editMode
-                  ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: TextField(
-                        readOnly: true,
-                        onTap: () => _selectDateTime(context),
-                        controller: TextEditingController(
-                          text: selectedDate!.krDate,
-                        ), // 날짜를 TextField에 표시
-                        decoration: customInputDecoration(
-                          labelText: '날짜',
-                        ),
-                        style: const TextStyle(fontSize: 16),
-                      ),
-                    )
-                  : Text(
-                      '📅 ${controller.schedule.value!.date.krDate}',
-                      style: const TextStyle(fontSize: 14, color: Colors.grey),
-                    ),
-
-              const SizedBox(height: 16),
-
-              // 🏡 장소 (수정 가능)
-              editMode
-                  ? Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Row(
-                        children: [
-                          Flexible(
-                            child: TextField(
-                              controller: locationController,
-                              decoration:
-                                  customInputDecoration(labelText: '장소'),
-                              style: const TextStyle(fontSize: 16),
-                            ),
-                          ),
-                        ],
-                      ),
-                    )
-                  : SizedBox(
-                      width: 250,
-                      child: Text(
-                        '🏡 ${controller.schedule.value!.location}',
-                        textAlign: TextAlign.center,
-                        style: const TextStyle(fontSize: 14),
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-
-              const SizedBox(height: 12),
-
-              // 🔗 링크 열기 / 수정 불가
               editMode
                   ? Container()
-                  : GestureDetector(
-                      onTap: () async {
-                        final Uri url =
-                            Uri.parse(controller.schedule.value!.link);
-                        if (await canLaunchUrl(url)) {
-                          await launchUrl(url,
-                              mode: LaunchMode.externalApplication);
-                        }
+                  : IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        _showDeleteDialog();
                       },
-                      child: const Row(
+                    ),
+            ],
+          ),
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // 📸 사진 (수정 불가능)
+                Container(
+                  width: 200,
+                  height: 200,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    image: DecorationImage(
+                      image: CachedNetworkImageProvider(
+                          cubit.state.schedule!.thumbnail),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+
+                // 👰‍♀️ & 🤵‍♂️ 신랑 & 신부 (수정 가능)
+                editMode
+                    ? Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Text(
-                            '🔗 링크 열기',
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: Colors.blue,
+                          Expanded(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16.0),
+                              child: TextField(
+                                controller: groomController,
+                                decoration:
+                                    customInputDecoration(labelText: '신랑'),
+                                style: const TextStyle(fontSize: 16),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16.0),
+                              child: TextField(
+                                controller: brideController,
+                                decoration:
+                                    customInputDecoration(labelText: '신부'),
+                                style: const TextStyle(fontSize: 16),
+                              ),
                             ),
                           ),
                         ],
+                      )
+                    : Text(
+                        '🤵‍♂️ ${cubit.state.schedule!.groom} & 👰‍♀️ ${cubit.state.schedule!.bride}',
+                        style: const TextStyle(
+                            fontSize: 18, fontWeight: FontWeight.bold),
                       ),
-                    ),
 
-              const SizedBox(height: 8),
+                const SizedBox(height: 16),
 
-              // 💰 축의금 (수정 가능)
-              // editMode
-              //     ? SizedBox(
-              //         width: 150,
-              //         child: TextField(
-              //           // controller: payController,
-              //           keyboardType: TextInputType.number,
-              //           decoration: const InputDecoration(labelText: '축의금'),
-              //         ),
-              //       )
-              //     : Text(
-              //         // '💰 축의금 ${controller.schedule.value!.pay}만원',
-              //         '💰 축의금 10만원',
-              //         style: const TextStyle(
-              //             fontSize: 16, fontWeight: FontWeight.bold),
-              //       ),
-            ],
+                editMode
+                    ? Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: TextField(
+                          readOnly: true,
+                          onTap: () => _selectDateTime(context),
+                          controller: TextEditingController(
+                            text: selectedDate!.krDate,
+                          ), // 날짜를 TextField에 표시
+                          decoration: customInputDecoration(
+                            labelText: '날짜',
+                          ),
+                          style: const TextStyle(fontSize: 16),
+                        ),
+                      )
+                    : Text(
+                        '📅 ${cubit.state.schedule!.date.krDate}',
+                        style:
+                            const TextStyle(fontSize: 14, color: Colors.grey),
+                      ),
+
+                const SizedBox(height: 16),
+
+                // 🏡 장소 (수정 가능)
+                editMode
+                    ? Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        child: Row(
+                          children: [
+                            Flexible(
+                              child: TextField(
+                                controller: locationController,
+                                decoration:
+                                    customInputDecoration(labelText: '장소'),
+                                style: const TextStyle(fontSize: 16),
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : SizedBox(
+                        width: 250,
+                        child: Text(
+                          '🏡 ${cubit.state.schedule!.location}',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(fontSize: 14),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+
+                const SizedBox(height: 12),
+
+                // 🔗 링크 열기 / 수정 불가
+                editMode
+                    ? Container()
+                    : GestureDetector(
+                        onTap: () async {
+                          final Uri url = Uri.parse(cubit.state.schedule!.link);
+                          if (await canLaunchUrl(url)) {
+                            await launchUrl(url,
+                                mode: LaunchMode.externalApplication);
+                          }
+                        },
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              '🔗 링크 열기',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Colors.blue,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+
+                const SizedBox(height: 8),
+
+                // 💰 축의금 (수정 가능)
+                // editMode
+                //     ? SizedBox(
+                //         width: 150,
+                //         child: TextField(
+                //           // controller: payController,
+                //           keyboardType: TextInputType.number,
+                //           decoration: const InputDecoration(labelText: '축의금'),
+                //         ),
+                //       )
+                //     : Text(
+                //         // '💰 축의금 ${controller.schedule.value!.pay}만원',
+                //         '💰 축의금 10만원',
+                //         style: const TextStyle(
+                //             fontSize: 16, fontWeight: FontWeight.bold),
+                //       ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/presentation/widgets/calendar_list_view.dart
+++ b/lib/presentation/widgets/calendar_list_view.dart
@@ -1,30 +1,30 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '../controllers/calendar_viewmodel.dart';
+import '../bloc/calendar/calendar_bloc.dart';
+import '../bloc/calendar/calendar_state.dart';
 import 'schedule_list_tile.dart';
 
-// ignore: use_key_in_widget_constructors
 class CalendarListView extends StatelessWidget {
-  final CalendarController _controller = Get.find<CalendarController>();
+  const CalendarListView({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         Expanded(
-          child: Obx(() {
-            if (_controller.allSchedules.isEmpty) {
+          child: BlocBuilder<CalendarBloc, CalendarState>(
+              builder: (context, state) {
+            if (state.allSchedules.isEmpty) {
               return const Center(child: Text("일정이 없습니다."));
             }
 
             final now = DateTime.now();
-            final pastSchedules = _controller.allSchedules
-                .where((s) => s.date.isBefore(now))
-                .toList();
+            final pastSchedules =
+                state.allSchedules.where((s) => s.date.isBefore(now)).toList();
 
-            final upcomingSchedules = _controller.allSchedules
-                .where((s) => !s.date.isBefore(now))
-                .toList();
+            final upcomingSchedules =
+                state.allSchedules.where((s) => !s.date.isBefore(now)).toList();
 
             return ListView(
               children: [

--- a/lib/presentation/widgets/calendar_view.dart
+++ b/lib/presentation/widgets/calendar_view.dart
@@ -1,23 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-import '../controllers/calendar_viewmodel.dart';
+import '../bloc/calendar/calendar_bloc.dart';
+import '../bloc/calendar/calendar_event.dart';
+import '../bloc/calendar/calendar_state.dart';
 import '../theme/palette.dart';
 import 'schedule_list_tile.dart';
 
-// ignore: use_key_in_widget_constructors
 class CalendarView extends StatelessWidget {
-  final CalendarController _controller = Get.find<CalendarController>();
+  const CalendarView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Obx(() {
-      final normalizedSelectedDay = DateTime(
-          _controller.selectedDay.value.year,
-          _controller.selectedDay.value.month,
-          _controller.selectedDay.value.day);
-      final eventCounts = _controller.currentMonthSchedules;
+    return BlocBuilder<CalendarBloc, CalendarState>(builder: (context, state) {
+      final normalizedSelectedDay = DateTime(state.selectedDay.year,
+          state.selectedDay.month, state.selectedDay.day);
+      final eventCounts = state.currentMonthSchedules;
       return Column(
         children: [
           TableCalendar(
@@ -25,14 +24,15 @@ class CalendarView extends StatelessWidget {
             locale: 'ko_KR',
             firstDay: DateTime(2000, 1, 1),
             lastDay: DateTime(2100, 12, 31),
-            focusedDay: _controller.focusedDay.value,
-            selectedDayPredicate: (day) =>
-                isSameDay(_controller.selectedDay.value, day),
+            focusedDay: state.focusedDay,
+            selectedDayPredicate: (day) => isSameDay(state.selectedDay, day),
             onDaySelected: (selectedDay, focusedDay) {
-              _controller.onDaySelected(selectedDay, focusedDay);
+              context
+                  .read<CalendarBloc>()
+                  .add(DaySelected(selectedDay, focusedDay));
             },
             onPageChanged: (focusedDay) {
-              _controller.onPageChanged(focusedDay);
+              context.read<CalendarBloc>().add(PageChanged(focusedDay));
             },
             calendarFormat: CalendarFormat.month,
             availableCalendarFormats: const {


### PR DESCRIPTION
## Related Issue

#9 

## Related PR

#12 

## Changes

- Apply `BlocBuilder`, `BlocProvider` in UI layer which will be connected with bloc, cubit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Migrated state management from GetX to Flutter Bloc across calendar, create, and detail pages, as well as calendar-related widgets.
  - Updated navigation and dialog handling to use standard Flutter APIs instead of GetX.
  - Improved consistency in UI updates and state handling using BlocBuilder.
  - Modified constructors for some widgets to accept required parameters and use const constructors where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->