### PR TITLE
[fix] UI overflow by using SafeArea, adding Padding to TutorialManager

### DIFF
--- a/lib/core/services/tutorial_manager.dart
+++ b/lib/core/services/tutorial_manager.dart
@@ -147,6 +147,7 @@ class TutorialManager {
         radius: 8,
         contents: [
           TargetContent(
+            padding: const EdgeInsets.fromLTRB(16, 48, 0, 0),
             align: ContentAlign.right,
             child: Column(
               mainAxisSize: MainAxisSize.min,

--- a/lib/presentation/pages/about_page.dart
+++ b/lib/presentation/pages/about_page.dart
@@ -8,40 +8,43 @@ class AboutPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('앱 정보')),
-      body: FutureBuilder<PackageInfo>(
-        future: PackageInfo.fromPlatform(),
-        builder: (context, snapshot) {
-          final version = snapshot.hasData
-              ? '버전 ${snapshot.data!.version} (${snapshot.data!.buildNumber})'
-              : '버전 정보 불러오는 중...';
+    return SafeArea(
+      top: false,
+      child: Scaffold(
+        appBar: AppBar(title: const Text('앱 정보')),
+        body: FutureBuilder<PackageInfo>(
+          future: PackageInfo.fromPlatform(),
+          builder: (context, snapshot) {
+            final version = snapshot.hasData
+                ? '버전 ${snapshot.data!.version} (${snapshot.data!.buildNumber})'
+                : '버전 정보 불러오는 중...';
 
-          return ListView(
-            children: [
-              ListTile(
-                title: const Text('앱 버전'),
-                subtitle: Text(version),
-              ),
-              const Divider(),
-              ListTile(
-                title: const Text('앱 업데이트'),
-                trailing: const Icon(Icons.chevron_right),
-                onTap: () {
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(const SnackBar(content: Text('최신 버전입니다.')));
-                },
-              ),
-              const Divider(),
-              ListTile(
-                title: const Text('개발자 정보'),
-                trailing: const Icon(Icons.chevron_right),
-                onTap: () => navigatorKey.currentState
-                    ?.pushNamed('/about/developer_info'),
-              ),
-            ],
-          );
-        },
+            return ListView(
+              children: [
+                ListTile(
+                  title: const Text('앱 버전'),
+                  subtitle: Text(version),
+                ),
+                const Divider(),
+                ListTile(
+                  title: const Text('앱 업데이트'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('최신 버전입니다.')));
+                  },
+                ),
+                const Divider(),
+                ListTile(
+                  title: const Text('개발자 정보'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () => navigatorKey.currentState
+                      ?.pushNamed('/about/developer_info'),
+                ),
+              ],
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/presentation/pages/calendar_page.dart
+++ b/lib/presentation/pages/calendar_page.dart
@@ -36,34 +36,37 @@ class _CalendarPageState extends State<CalendarPage> {
   Widget build(BuildContext context) {
     return BlocProvider<CalendarBloc>.value(
       value: bloc,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(
-            '일정',
-            style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: Palette.black),
-          ),
-          actions: [
-            IconButton(
-              icon: Icon(_isCalendarView ? Icons.list : Icons.calendar_month),
-              onPressed: () {
-                setState(() {
-                  _isCalendarView = !_isCalendarView;
-                });
-              },
+      child: SafeArea(
+        top: false,
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(
+              '일정',
+              style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Palette.black),
             ),
-          ],
+            actions: [
+              IconButton(
+                icon: Icon(_isCalendarView ? Icons.list : Icons.calendar_month),
+                onPressed: () {
+                  setState(() {
+                    _isCalendarView = !_isCalendarView;
+                  });
+                },
+              ),
+            ],
+          ),
+          body: BlocBuilder<CalendarBloc, CalendarState>(
+              builder: (context, state) {
+            return state.isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : _isCalendarView
+                    ? const CalendarView()
+                    : const CalendarListView();
+          }),
         ),
-        body:
-            BlocBuilder<CalendarBloc, CalendarState>(builder: (context, state) {
-          return state.isLoading
-              ? const Center(child: CircularProgressIndicator())
-              : _isCalendarView
-                  ? const CalendarView()
-                  : const CalendarListView();
-        }),
       ),
     );
   }

--- a/lib/presentation/pages/create_page.dart
+++ b/lib/presentation/pages/create_page.dart
@@ -77,230 +77,236 @@ class _CreatePageState extends State<CreatePage> {
   Widget build(BuildContext context) {
     return BlocProvider<CreateCubit>.value(
       value: cubit,
-      child: Scaffold(
-        appBar: AppBar(
-          leading: IconButton(
-            key: calendarPageKey,
-            icon: const Icon(Icons.calendar_today),
-            onPressed: () {
-              navigatorKey.currentState?.pushNamed('/calendar');
-            },
-          ),
-          actions: [
-            /// Only shows notification button in `kDebugMode`.
-            kDebugMode
-                ? IconButton(
-                    icon: const Icon(Icons.notifications),
-                    onPressed: () {
-                      cubit.notificationService.addTestNotifySchedule(id: 1);
-                      cubit.notificationService.checkScheduledNotifications();
-                      showDialog(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          title: const Text('알림'),
-                          content: const Text('스케쥴이 등록되었습니다.'),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.of(context).pop(),
-                              child: const Text('확인'),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                  )
-                : Container(),
-            PopupMenuButton<String>(
-              icon: const Icon(Icons.more_vert),
-              onSelected: (value) async {
-                switch (value) {
-                  case 'terms':
-                    final Uri url = Uri.parse(Constants.termsUrl);
-                    if (await canLaunchUrl(url)) {
-                      await launchUrl(url,
-                          mode: LaunchMode.externalApplication);
-                    }
-                    break;
-                  case 'privacy':
-                    final Uri url = Uri.parse(Constants.privacyUrl);
-                    if (await canLaunchUrl(url)) {
-                      await launchUrl(url,
-                          mode: LaunchMode.externalApplication);
-                    }
-                    break;
-                  case 'about':
-                    navigatorKey.currentState?.pushNamed('/about');
-                    break;
-                }
+      child: SafeArea(
+        top: false,
+        child: Scaffold(
+          appBar: AppBar(
+            leading: IconButton(
+              key: calendarPageKey,
+              icon: const Icon(Icons.calendar_today),
+              onPressed: () {
+                navigatorKey.currentState?.pushNamed('/calendar');
               },
-              itemBuilder: (context) => [
-                const PopupMenuItem(
-                  value: 'terms',
-                  child: Text('이용 약관'),
-                ),
-                const PopupMenuItem(
-                  value: 'privacy',
-                  child: Text('개인정보 처리방침'),
-                ),
-                const PopupMenuItem(
-                  value: 'about',
-                  child: Text('앱 정보'),
-                ),
-              ],
             ),
-          ],
-        ),
-        body: Stack(
-          children: [
-            const Positioned(
-              top: 10,
-              left: 30,
-              child: Text('홈',
-                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-            ),
-            Center(
-              child: BlocBuilder<CreateCubit, CreateState>(
-                  builder: (context, state) {
-                if (state.isLoading) {
-                  return Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      SizedBox(
-                        width: 250,
-                        height: 250,
-                        child: DotLottieLoader.fromAsset(
-                            'assets/images/analyze.lottie', frameBuilder:
-                                (BuildContext ctx, DotLottie? dotlottie) {
-                          if (dotlottie != null) {
-                            return Lottie.memory(
-                                dotlottie.animations.values.single);
-                          } else {
-                            return const CircularProgressIndicator();
-                          }
-                        }),
-                      ),
-                      const SizedBox(height: 16),
-                      const Text('링크 분석 중...', style: TextStyle(fontSize: 16)),
-                    ],
-                  );
-                }
-                return state.isError
-                    ? const Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Text(
-                            '다시 시도해주세요.',
-                            style: TextStyle(
-                                fontSize: 18, fontWeight: FontWeight.bold),
-                          ),
-                          Text(
-                            '잠시 서버에 문제가 생겼어요.',
-                            style: TextStyle(fontSize: 14),
-                          )
-                        ],
-                      )
-                    : state.schedule != null
-                        ? ScheduleDetailColumn(
-                            schedule: state.schedule!,
-                            extraChildren: [
-                              const SizedBox(height: 12),
-                              Text(
-                                '분석 결과를 일정에 추가할게요.',
-                                style: TextStyle(
-                                    fontSize: 16,
-                                    fontWeight: FontWeight.w500,
-                                    color: Palette.burgundy),
-                              ),
-                            ],
-                          )
-                        : Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Text(
-                                key: resultBodyKey,
-                                '모바일 청첩장을 첨부해주세요.',
-                                style: const TextStyle(
-                                    fontSize: 18, fontWeight: FontWeight.bold),
-                              ),
-                              const Text(
-                                'AI가 자동으로 일정을 분석해드릴게요.',
-                                style: TextStyle(fontSize: 14),
-                              )
-                            ],
-                          );
-              }),
-            ),
-          ],
-        ),
-        bottomSheet:
-            BlocBuilder<CreateCubit, CreateState>(builder: (context, state) {
-          return state.schedule != null
-              ? Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
+            actions: [
+              /// Only shows notification button in `kDebugMode`.
+              kDebugMode
+                  ? IconButton(
+                      icon: const Icon(Icons.notifications),
                       onPressed: () {
-                        cubit.resetState();
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('일정을 캘린더에 저장했습니다.')),
+                        cubit.notificationService.addTestNotifySchedule(id: 1);
+                        cubit.notificationService.checkScheduledNotifications();
+                        showDialog(
+                          context: context,
+                          builder: (_) => AlertDialog(
+                            title: const Text('알림'),
+                            content: const Text('스케쥴이 등록되었습니다.'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.of(context).pop(),
+                                child: const Text('확인'),
+                              ),
+                            ],
+                          ),
                         );
                       },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Palette.burgundy,
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                      ),
-                      child: const Text(
-                        "확인",
-                        style: TextStyle(
-                            fontSize: 16, fontWeight: FontWeight.bold),
-                      ),
-                    ),
+                    )
+                  : Container(),
+              PopupMenuButton<String>(
+                icon: const Icon(Icons.more_vert),
+                onSelected: (value) async {
+                  switch (value) {
+                    case 'terms':
+                      final Uri url = Uri.parse(Constants.termsUrl);
+                      if (await canLaunchUrl(url)) {
+                        await launchUrl(url,
+                            mode: LaunchMode.externalApplication);
+                      }
+                      break;
+                    case 'privacy':
+                      final Uri url = Uri.parse(Constants.privacyUrl);
+                      if (await canLaunchUrl(url)) {
+                        await launchUrl(url,
+                            mode: LaunchMode.externalApplication);
+                      }
+                      break;
+                    case 'about':
+                      navigatorKey.currentState?.pushNamed('/about');
+                      break;
+                  }
+                },
+                itemBuilder: (context) => [
+                  const PopupMenuItem(
+                    value: 'terms',
+                    child: Text('이용 약관'),
                   ),
-                )
-              : Padding(
-                  key: linkInputKey,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.circular(12),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(
-                              red: 0, blue: 0, green: 0, alpha: 0.1),
-                          blurRadius: 10,
-                          spreadRadius: 1,
+                  const PopupMenuItem(
+                    value: 'privacy',
+                    child: Text('개인정보 처리방침'),
+                  ),
+                  const PopupMenuItem(
+                    value: 'about',
+                    child: Text('앱 정보'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          body: Stack(
+            children: [
+              const Positioned(
+                top: 10,
+                left: 30,
+                child: Text('홈',
+                    style:
+                        TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              ),
+              Center(
+                child: BlocBuilder<CreateCubit, CreateState>(
+                    builder: (context, state) {
+                  if (state.isLoading) {
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(
+                          width: 250,
+                          height: 250,
+                          child: DotLottieLoader.fromAsset(
+                              'assets/images/analyze.lottie', frameBuilder:
+                                  (BuildContext ctx, DotLottie? dotlottie) {
+                            if (dotlottie != null) {
+                              return Lottie.memory(
+                                  dotlottie.animations.values.single);
+                            } else {
+                              return const CircularProgressIndicator();
+                            }
+                          }),
                         ),
+                        const SizedBox(height: 16),
+                        const Text('링크 분석 중...',
+                            style: TextStyle(fontSize: 16)),
                       ],
-                    ),
-                    child: TextField(
-                      controller: _textEditingController,
-                      onSubmitted: (value) => _onSubmit(),
-                      style: const TextStyle(fontSize: 14),
-                      decoration: InputDecoration(
-                        hintText: '링크 입력...',
-                        hintStyle:
-                            TextStyle(fontSize: 14, color: Palette.grey500),
-                        contentPadding: const EdgeInsets.symmetric(
-                            vertical: 12, horizontal: 16),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                          borderSide: BorderSide.none,
+                    );
+                  }
+                  return state.isError
+                      ? const Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Text(
+                              '다시 시도해주세요.',
+                              style: TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.bold),
+                            ),
+                            Text(
+                              '잠시 서버에 문제가 생겼어요.',
+                              style: TextStyle(fontSize: 14),
+                            )
+                          ],
+                        )
+                      : state.schedule != null
+                          ? ScheduleDetailColumn(
+                              schedule: state.schedule!,
+                              extraChildren: [
+                                const SizedBox(height: 12),
+                                Text(
+                                  '분석 결과를 일정에 추가할게요.',
+                                  style: TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                      color: Palette.burgundy),
+                                ),
+                              ],
+                            )
+                          : Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  key: resultBodyKey,
+                                  '모바일 청첩장을 첨부해주세요.',
+                                  style: const TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.bold),
+                                ),
+                                const Text(
+                                  'AI가 자동으로 일정을 분석해드릴게요.',
+                                  style: TextStyle(fontSize: 14),
+                                )
+                              ],
+                            );
+                }),
+              ),
+            ],
+          ),
+          bottomSheet:
+              BlocBuilder<CreateCubit, CreateState>(builder: (context, state) {
+            return state.schedule != null
+                ? Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () {
+                          cubit.resetState();
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('일정을 캘린더에 저장했습니다.')),
+                          );
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Palette.burgundy,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
                         ),
-                        suffixIcon: IconButton(
-                          icon: const Icon(Icons.send, size: 20),
-                          onPressed: _onSubmit,
+                        child: const Text(
+                          "확인",
+                          style: TextStyle(
+                              fontSize: 16, fontWeight: FontWeight.bold),
                         ),
                       ),
                     ),
-                  ),
-                );
-        }),
+                  )
+                : Padding(
+                    key: linkInputKey,
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(12),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(
+                                red: 0, blue: 0, green: 0, alpha: 0.1),
+                            blurRadius: 10,
+                            spreadRadius: 1,
+                          ),
+                        ],
+                      ),
+                      child: TextField(
+                        controller: _textEditingController,
+                        onSubmitted: (value) => _onSubmit(),
+                        style: const TextStyle(fontSize: 14),
+                        decoration: InputDecoration(
+                          hintText: '링크 입력...',
+                          hintStyle:
+                              TextStyle(fontSize: 14, color: Palette.grey500),
+                          contentPadding: const EdgeInsets.symmetric(
+                              vertical: 12, horizontal: 16),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                            borderSide: BorderSide.none,
+                          ),
+                          suffixIcon: IconButton(
+                            icon: const Icon(Icons.send, size: 20),
+                            onPressed: _onSubmit,
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+          }),
+        ),
       ),
     );
   }

--- a/lib/presentation/pages/detail_page.dart
+++ b/lib/presentation/pages/detail_page.dart
@@ -171,179 +171,183 @@ class _DetailPageState extends State<DetailPage> {
           navigatorKey.currentState
               ?.popUntil((route) => route.settings.name == '/calendar');
         },
-        child: Scaffold(
-          appBar: AppBar(
-            actions: [
-              IconButton(
-                icon: Icon(editMode ? Icons.save : Icons.edit),
-                onPressed: editMode ? saveChanges : toggleEditMode,
-              ),
-              editMode
-                  ? Container()
-                  : IconButton(
-                      icon: const Icon(Icons.delete),
-                      onPressed: () {
-                        _showDeleteDialog();
-                      },
-                    ),
-            ],
-          ),
-          body: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                // 📸 사진 (수정 불가능)
-                Container(
-                  width: 200,
-                  height: 200,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    image: DecorationImage(
-                      image: CachedNetworkImageProvider(
-                          cubit.state.schedule!.thumbnail),
-                      fit: BoxFit.cover,
-                    ),
-                  ),
+        child: SafeArea(
+          top: false,
+          child: Scaffold(
+            appBar: AppBar(
+              actions: [
+                IconButton(
+                  icon: Icon(editMode ? Icons.save : Icons.edit),
+                  onPressed: editMode ? saveChanges : toggleEditMode,
                 ),
-                const SizedBox(height: 12),
-
-                // 👰‍♀️ & 🤵‍♂️ 신랑 & 신부 (수정 가능)
-                editMode
-                    ? Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Expanded(
-                            child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16.0),
-                              child: TextField(
-                                controller: groomController,
-                                decoration:
-                                    customInputDecoration(labelText: '신랑'),
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16.0),
-                              child: TextField(
-                                controller: brideController,
-                                decoration:
-                                    customInputDecoration(labelText: '신부'),
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
-                          ),
-                        ],
-                      )
-                    : Text(
-                        '🤵‍♂️ ${cubit.state.schedule!.groom} & 👰‍♀️ ${cubit.state.schedule!.bride}',
-                        style: const TextStyle(
-                            fontSize: 18, fontWeight: FontWeight.bold),
-                      ),
-
-                const SizedBox(height: 16),
-
-                editMode
-                    ? Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: TextField(
-                          readOnly: true,
-                          onTap: () => _selectDateTime(context),
-                          controller: TextEditingController(
-                            text: selectedDate!.krDate,
-                          ), // 날짜를 TextField에 표시
-                          decoration: customInputDecoration(
-                            labelText: '날짜',
-                          ),
-                          style: const TextStyle(fontSize: 16),
-                        ),
-                      )
-                    : Text(
-                        '📅 ${cubit.state.schedule!.date.krDate}',
-                        style:
-                            const TextStyle(fontSize: 14, color: Colors.grey),
-                      ),
-
-                const SizedBox(height: 16),
-
-                // 🏡 장소 (수정 가능)
-                editMode
-                    ? Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                        child: Row(
-                          children: [
-                            Flexible(
-                              child: TextField(
-                                controller: locationController,
-                                decoration:
-                                    customInputDecoration(labelText: '장소'),
-                                style: const TextStyle(fontSize: 16),
-                              ),
-                            ),
-                          ],
-                        ),
-                      )
-                    : SizedBox(
-                        width: 250,
-                        child: Text(
-                          '🏡 ${cubit.state.schedule!.location}',
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(fontSize: 14),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-
-                const SizedBox(height: 12),
-
-                // 🔗 링크 열기 / 수정 불가
                 editMode
                     ? Container()
-                    : GestureDetector(
-                        onTap: () async {
-                          final Uri url = Uri.parse(cubit.state.schedule!.link);
-                          if (await canLaunchUrl(url)) {
-                            await launchUrl(url,
-                                mode: LaunchMode.externalApplication);
-                          }
+                    : IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () {
+                          _showDeleteDialog();
                         },
-                        child: const Row(
+                      ),
+              ],
+            ),
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // 📸 사진 (수정 불가능)
+                  Container(
+                    width: 200,
+                    height: 200,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      image: DecorationImage(
+                        image: CachedNetworkImageProvider(
+                            cubit.state.schedule!.thumbnail),
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+
+                  // 👰‍♀️ & 🤵‍♂️ 신랑 & 신부 (수정 가능)
+                  editMode
+                      ? Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            Text(
-                              '🔗 링크 열기',
-                              style: TextStyle(
-                                fontSize: 14,
-                                color: Colors.blue,
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 16.0),
+                                child: TextField(
+                                  controller: groomController,
+                                  decoration:
+                                      customInputDecoration(labelText: '신랑'),
+                                  style: const TextStyle(fontSize: 16),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 16.0),
+                                child: TextField(
+                                  controller: brideController,
+                                  decoration:
+                                      customInputDecoration(labelText: '신부'),
+                                  style: const TextStyle(fontSize: 16),
+                                ),
                               ),
                             ),
                           ],
+                        )
+                      : Text(
+                          '🤵‍♂️ ${cubit.state.schedule!.groom} & 👰‍♀️ ${cubit.state.schedule!.bride}',
+                          style: const TextStyle(
+                              fontSize: 18, fontWeight: FontWeight.bold),
                         ),
-                      ),
 
-                const SizedBox(height: 8),
+                  const SizedBox(height: 16),
 
-                // 💰 축의금 (수정 가능)
-                // editMode
-                //     ? SizedBox(
-                //         width: 150,
-                //         child: TextField(
-                //           // controller: payController,
-                //           keyboardType: TextInputType.number,
-                //           decoration: const InputDecoration(labelText: '축의금'),
-                //         ),
-                //       )
-                //     : Text(
-                //         // '💰 축의금 ${controller.schedule.value!.pay}만원',
-                //         '💰 축의금 10만원',
-                //         style: const TextStyle(
-                //             fontSize: 16, fontWeight: FontWeight.bold),
-                //       ),
-              ],
+                  editMode
+                      ? Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: TextField(
+                            readOnly: true,
+                            onTap: () => _selectDateTime(context),
+                            controller: TextEditingController(
+                              text: selectedDate!.krDate,
+                            ), // 날짜를 TextField에 표시
+                            decoration: customInputDecoration(
+                              labelText: '날짜',
+                            ),
+                            style: const TextStyle(fontSize: 16),
+                          ),
+                        )
+                      : Text(
+                          '📅 ${cubit.state.schedule!.date.krDate}',
+                          style:
+                              const TextStyle(fontSize: 14, color: Colors.grey),
+                        ),
+
+                  const SizedBox(height: 16),
+
+                  // 🏡 장소 (수정 가능)
+                  editMode
+                      ? Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                          child: Row(
+                            children: [
+                              Flexible(
+                                child: TextField(
+                                  controller: locationController,
+                                  decoration:
+                                      customInputDecoration(labelText: '장소'),
+                                  style: const TextStyle(fontSize: 16),
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : SizedBox(
+                          width: 250,
+                          child: Text(
+                            '🏡 ${cubit.state.schedule!.location}',
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(fontSize: 14),
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+
+                  const SizedBox(height: 12),
+
+                  // 🔗 링크 열기 / 수정 불가
+                  editMode
+                      ? Container()
+                      : GestureDetector(
+                          onTap: () async {
+                            final Uri url =
+                                Uri.parse(cubit.state.schedule!.link);
+                            if (await canLaunchUrl(url)) {
+                              await launchUrl(url,
+                                  mode: LaunchMode.externalApplication);
+                            }
+                          },
+                          child: const Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                '🔗 링크 열기',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  color: Colors.blue,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+
+                  const SizedBox(height: 8),
+
+                  // 💰 축의금 (수정 가능)
+                  // editMode
+                  //     ? SizedBox(
+                  //         width: 150,
+                  //         child: TextField(
+                  //           // controller: payController,
+                  //           keyboardType: TextInputType.number,
+                  //           decoration: const InputDecoration(labelText: '축의금'),
+                  //         ),
+                  //       )
+                  //     : Text(
+                  //         // '💰 축의금 ${controller.schedule.value!.pay}만원',
+                  //         '💰 축의금 10만원',
+                  //         style: const TextStyle(
+                  //             fontSize: 16, fontWeight: FontWeight.bold),
+                  //       ),
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Related Issue : #16 

## Changed

1. Applied `SafeArea` with `top: false` option for every Scaffold page
- We are using `AppBar` from `Scaffold`, so applying `SafeArea` to top side made status bar black.
- So I've used `top: false` option for `SafeArea`.

2. Added padding to `TutorialManager`'s `TargetContent` which overflows top-side.
- `TutorialManager` is on the top of whole widgets & screen.
- So we need to prevent overflow with each manual padding instead of `SafeArea`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout consistency by wrapping key pages (About, Calendar, Create, and Detail) in a SafeArea to prevent content from being obscured by device overlays, except for the top edge.
  * Adjusted padding for the tutorial content on the calendar page for better visual spacing.
  * Minor reordering of action buttons in the Create page’s app bar for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->